### PR TITLE
In my haste, I removed the required attribute to the renderWith

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # set version
-VERSION=0.2.1
+VERSION=0.2.2
 
 # set file name
 ZIPFILE=SanitizeModels-$VERSION.zip

--- a/src/sanitizemodels.cfc
+++ b/src/sanitizemodels.cfc
@@ -52,7 +52,7 @@ component output="false" mixin="controller,model" {
         return arguments.modelObject;
     }
 
-    public function renderWith(boolean sanitize) {
+    public function renderWith(required any data, boolean sanitize) {
         if (!isQuery(arguments.data)) {
             var isSanitizedRequired = False;
             try {


### PR DESCRIPTION
This is evident why unit tests would be helpful.  If a controler called
renderWith(data) without the sanitize attribute, it would fail.  When
adding the required data attribute, it addresses this problem.